### PR TITLE
Updated scrapbook size stats module constant

### DIFF
--- a/js/util.js
+++ b/js/util.js
@@ -132,7 +132,7 @@ class Constants {
             'normal': 100,
             'large': 160,
             'huge': 200,
-            'scrapbook': 2200,
+            'scrapbook': SCRAPBOOK_COUNT,
             'max': -1,
             'weapon': 1,
             'shield': 2,


### PR DESCRIPTION
Changed scrapbook size stats module constant to automatically fetch for global scrapbook size constant SCRAPBOOK_COUNT

**Checklist:**
- [x] Have tested the modifications by running local server
