### PR TITLE
Few additions

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -396,6 +396,10 @@ class Editor extends EditorBase {
                 {
                     name: this.intl('lightning'),
                     value: 42
+                },
+                {
+                    name: this.intl('optimal'),
+                    value: 187
                 }
             ],
             value: '0'
@@ -418,6 +422,10 @@ class Editor extends EditorBase {
                 {
                     name: this.intl('lightning'),
                     value: 42
+                },
+                {
+                    name: this.intl('optimal'),
+                    value: 187
                 }
             ],
             value: '0'

--- a/js/lang/en.json
+++ b/js/lang/en.json
@@ -1349,6 +1349,7 @@
         "hand_enchant": "Shadow of the Cowboy",
         "smart_change": "Smart class change",
         "copy": "Copy",
+        "optimal": "Optimal",
         "none": "None"
     },
     "endpoint": {

--- a/js/pages/analyzer.js
+++ b/js/pages/analyzer.js
@@ -90,6 +90,10 @@ class PlayerEditor extends EditorBase {
                 {
                     name: intl('editor.lightning'),
                     value: 42
+                },
+                {
+                    name: intl('editor.optimal'),
+                    value: 187
                 }
             ],
             value: '0'
@@ -112,6 +116,10 @@ class PlayerEditor extends EditorBase {
                 {
                     name: intl('editor.lightning'),
                     value: 42
+                },
+                {
+                    name: intl('editor.optimal'),
+                    value: 187
                 }
             ],
             value: '0'


### PR DESCRIPTION
Hi Mar,

it's me Eggman, here are some of my personal modifications of sftools.


List of changes/additions:
- added an option to the rune dropdown, so that the sim automatically picks the rune that works best vs your opponent
			
 	<ins>Debug Tools</ins>:
- changed the order of some of the variables
- added a damage multiplier to all classes that were missing one
- added a toggle that would overwrite the block chance of all warriors with the set debug maximum block chance
- added a variable to give mage a dodge chance (plus a toggle to also dodge other mages)
- added an option to enable a scaling fireball for bm (the fireball damage and its cap changes depending on its max armor)
- added a toggle to uncap the max damage of the fireball
- added an adjustable rage chance to berserk 
- added a revive damage decay variable to DH

(I put "Bool_" in front of all the variables that are bools, so it is easier to tell them apart from the 'normal' variables)