### PR TITLE
Few additions - Part 2

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -396,6 +396,10 @@ class Editor extends EditorBase {
                 {
                     name: this.intl('lightning'),
                     value: 42
+                },
+                {
+                    name: this.intl('optimal'),
+                    value: 187
                 }
             ],
             value: '0'
@@ -418,6 +422,10 @@ class Editor extends EditorBase {
                 {
                     name: this.intl('lightning'),
                     value: 42
+                },
+                {
+                    name: this.intl('optimal'),
+                    value: 187
                 }
             ],
             value: '0'

--- a/js/lang/en.json
+++ b/js/lang/en.json
@@ -1350,6 +1350,7 @@
         "hand_enchant": "Shadow of the Cowboy",
         "smart_change": "Smart class change",
         "copy": "Copy",
+        "optimal": "''Optimal''",
         "none": "None"
     },
     "endpoint": {

--- a/js/pages/analyzer.js
+++ b/js/pages/analyzer.js
@@ -90,6 +90,10 @@ class PlayerEditor extends EditorBase {
                 {
                     name: intl('editor.lightning'),
                     value: 42
+                },
+                {
+                    name: intl('editor.optimal'),
+                    value: 187
                 }
             ],
             value: '0'
@@ -112,6 +116,10 @@ class PlayerEditor extends EditorBase {
                 {
                     name: intl('editor.lightning'),
                     value: 42
+                },
+                {
+                    name: intl('editor.optimal'),
+                    value: 187
                 }
             ],
             value: '0'

--- a/js/sim/base.js
+++ b/js/sim/base.js
@@ -223,6 +223,7 @@ const CONFIG = Object.defineProperties(
             WeaponMultiplier: 2,
             DamageMultiplier: 1,
             Bool_DynamicFireballDmgScaling: false,
+            Bool_FBDmgScalesWithCurrentHp : false,
             Bool_NoFireballDmgCap: false,
             MaximumDamageReduction: 10,
             MaximumDamageReductionMultiplier: 5,
@@ -817,21 +818,25 @@ class BattlemageModel extends SimulatorModel {
             return 0;
         } else {
             let multiplierF;
-            let multiplier;
+            let multiplier = 0.05 * target.Config.HealthMultiplier;
+            let bmhp = this.TotalHealth;
+            let fbcap = (1/3);
             if (this.Config.Bool_DynamicFireballDmgScaling) {
                 multiplierF = (1 - 0.375 / ( 1 - (this.Config.MaximumDamageReduction * this.Config.MaximumDamageReductionMultiplier)/100));
                 multiplier = multiplierF / this.Config.HealthMultiplier * target.Config.HealthMultiplier;
-            } else {
-                multiplier = 0.05 * target.Config.HealthMultiplier;
             }
 
-            if (!this.Config.Bool_NoFireballDmgCap && this.Config.Bool_DynamicFireballDmgScaling) {
-                return Math.min(Math.ceil(target.TotalHealth * (1/(1-multiplierF)-1)), Math.ceil(this.TotalHealth * multiplier));
-            } else if (!this.Config.Bool_NoFireballDmgCap) {
-                return Math.min(Math.ceil(target.TotalHealth / 3), Math.ceil(this.TotalHealth * multiplier));
-            } else {
-                return Math.ceil(this.TotalHealth * multiplier);
+            if (this.Bool_FBDmgScalesWithCurrentHp) {
+                bmhp = this.Health;
             }
+
+            if (this.Config.Bool_NoFireballDmgCap) {
+                fbcap = 1;
+            } else if (this.Config.Bool_DynamicFireballDmgScaling) {
+                fbcap = Math.ceil(1/(1-multiplierF)-1);
+            }
+
+            return Math.min(Math.ceil(target.TotalHealth * fbcap), Math.ceil( bmhp * multiplier));
         }
     }
 

--- a/js/sim/base.js
+++ b/js/sim/base.js
@@ -824,6 +824,7 @@ class BattlemageModel extends SimulatorModel {
             if (this.Config.Bool_DynamicFireballDmgScaling) {
                 multiplierF = (1 - 0.375 / ( 1 - (this.Config.MaximumDamageReduction * this.Config.MaximumDamageReductionMultiplier)/100));
                 multiplier = multiplierF / this.Config.HealthMultiplier * target.Config.HealthMultiplier;
+                fbcap = Math.ceil(1/(1-multiplierF)-1);
             }
 
             if (this.Bool_FBDmgScalesWithCurrentHp) {
@@ -832,8 +833,6 @@ class BattlemageModel extends SimulatorModel {
 
             if (this.Config.Bool_NoFireballDmgCap) {
                 fbcap = 1;
-            } else if (this.Config.Bool_DynamicFireballDmgScaling) {
-                fbcap = Math.ceil(1/(1-multiplierF)-1);
             }
 
             return Math.min(Math.ceil(target.TotalHealth * fbcap), Math.ceil( bmhp * multiplier));


### PR DESCRIPTION
Hi Mar,

your most recent update included many things i wished for, here are the things that are left:

List of changes/additions:
- added a "new" rune to the rune dropdown, the sim will automatically pick the rune that works best vs the opponents resistance 
			
 	<ins>Debug Tools</ins>:
- added a toggle that would overwrite the block chance of all (Player) warriors with the set debug maximum block chance
(this is there to overwrite the block chance of player warrior, that were captured or added manually)
- added an option to enable a scaling fireball (the damage and its cap depends on bms max armor and hp multiplier)
- added a toggle to uncap the max damage of the fireball
- added a revive damage decay variable to DH

New:
- refactored the bm changes a bit
- added the option to have the fireball to scale with bms current hp

(I put "Bool_" in front of all the variables that are bools, so it is easier to tell them apart from the 'normal' variables)