### PR TITLE
Added sandstorm and twister to MORE dungeon simulation

### DIFF
--- a/js/lang/en.json
+++ b/js/lang/en.json
@@ -893,6 +893,10 @@
         "simulate_next_info": {
             "title": "No dungeons beatable within threshold (#{threshold_min} - #{threshold_max} %)",
             "message#": "Use <b>All</b> function to simulate all open dungeons"
+        },
+        "simulate_next_options": {
+            "includeTwister": "Include Twister",
+            "includeSandstorm": "Include Sandstorm"
         }
     },
     "underworld": {

--- a/js/pages/dungeons.js
+++ b/js/pages/dungeons.js
@@ -5,7 +5,9 @@ Site.ready({ name: 'dungeons', type: 'simulator', requires: ['translations_monst
         'dungeons',
         {
             threshold_min: 5,
-            threshold_max: 100
+            threshold_max: 100,
+            includeTwister: false,
+            includeSandstorm: false,
         }
     );
 
@@ -607,8 +609,13 @@ Site.ready({ name: 'dungeons', type: 'simulator', requires: ['translations_monst
             
             let pending = [];
             for (const { boss: _boss, dungeon: _dungeon } of availableBosses) {
-                if (_dungeon.id === 203 || _dungeon.id === 204) {
-                    // Ignore twister and sandstorm
+                // Skip Twister
+                if (_dungeon.id === 203 && !dungeonOptions.includeTwister) {
+                    continue;
+                }
+
+                // Skip Sandstorm
+                if (_dungeon.id === 204 && !dungeonOptions.includeSandstorm) {
                     continue;
                 }
 

--- a/js/sim/base.js
+++ b/js/sim/base.js
@@ -348,6 +348,8 @@ const CONFIG = Object.defineProperties(
             SkipType: SKIP_TYPE_DEFAULT,
             SkipVariant: DEFENSE_TYPE_NONE,
 
+            ConIntRatioDependentRoundBonus: true,//Playa wants to remove this in some future update, with that toggle it could be tested now
+
             EffectRounds: 4,
             EffectBaseDuration: [1, 1, 2],
             EffectBaseChance: [25, 50, 25],
@@ -1232,10 +1234,10 @@ class BardModel extends SimulatorModel {
         const attribute = this.getAttribute(this);
         const constitution = this.Player.Constitution.Total * (1 + (this.Snack.ConstitutionBonus ?? 0));
 
-        if (constitution >= attribute / 2) {
+        if (constitution >= attribute / 2 || !this.Config.ConIntRatioDependentRoundBonus) {
             this.BonusRounds++;
         }
-        if (constitution >= 3 * attribute / 4) {
+        if (constitution >= 3 * attribute / 4 || !this.Config.ConIntRatioDependentRoundBonus) {
             this.BonusRounds++;
         }
     }

--- a/js/sim/base.js
+++ b/js/sim/base.js
@@ -383,7 +383,7 @@ const CONFIG = Object.defineProperties(
                     CriticalBonus: 0,
                     CriticalChance: 0.5,
                     CriticalChanceBonus: 0,
-                    ReviveCount: 2,
+                    ReviveCount: 1,//should be 2; sfgame is bugged, for some reason the skeleton only revives once
                     ReviveDuration: 1,
                     ReviveChance: 0.5
                 },
@@ -1447,7 +1447,7 @@ class NecromancerModel extends SimulatorModel {
         // Remove minion if expired
         if (this.MinionDuration <= 0) {
             // Check if minion can be revived
-            if (getRandom(this.MinionRevives)) {
+            if (getRandom(this.Minion.Config.ReviveChance) && this.MinionRevives > 0) {//sftools had a bug here, it never checked for the revive chance, only if revives are left
                 this.MinionDuration = this.Minion.Config.ReviveDuration;
                 this.MinionRevives--;
             } else {

--- a/js/views/dungeons.js
+++ b/js/views/dungeons.js
@@ -28,6 +28,20 @@ class SimulatorOptionsDialog extends Dialog {
                           </div>
                       </div>
                   </div>
+                  <div class="two fields">
+                      <div class="field">
+                          <div class="ui inverted checkbox">
+                              <input type="checkbox" data-op="includeTwister">
+                              <label>${intl('dungeons.simulate_next_options.includeTwister')}</label>
+                          </div>
+                      </div>
+                      <div class="field">
+                          <div class="ui inverted checkbox">
+                              <input type="checkbox" data-op="includeSandstorm">
+                              <label>${intl('dungeons.simulate_next_options.includeSandstorm')}</label>
+                          </div>
+                      </div>
+                  </div>
               </div>
               <div class="ui two fluid buttons">
                   <button class="ui black button" data-op="cancel">${intl('dialog.shared.cancel')}</button>
@@ -52,9 +66,25 @@ class SimulatorOptionsDialog extends Dialog {
 
   #update (updateInputs) {
     this.$slider.slider('set rangeValue', this.currentMin, this.currentMax, updateInputs);
+    if (updateInputs) {
+      this.$includeTwister.prop('checked', this.currentTwister);
+      this.$includeSandstorm.prop('checked', this.currentSandstorm);
+    }
   }
 
   handle (options) {
+    this.$includeTwister = this.$parent.find('[data-op="includeTwister"]');
+    this.$includeTwister.on('input', () => {
+      this.currentTwister = this.$includeTwister.prop('checked');
+      this.#update(false);
+    });
+
+    this.$includeSandstorm = this.$parent.find('[data-op="includeSandstorm"]');
+    this.$includeSandstorm.on('input', () => {
+      this.currentSandstorm = this.$includeSandstorm.prop('checked');
+      this.#update(false);
+    });
+
     this.$slider = this.$parent.find('[data-op="slider"]');
     this.$slider.slider({
       min: 0,
@@ -92,6 +122,8 @@ class SimulatorOptionsDialog extends Dialog {
     this.$okButton.click(() => {
       this.simulatorOptions.threshold_min = this.currentMin;
       this.simulatorOptions.threshold_max = this.currentMax;
+      this.simulatorOptions.includeTwister = this.currentTwister;
+      this.simulatorOptions.includeSandstorm = this.currentSandstorm;
 
       this.close(true);
     });
@@ -104,6 +136,8 @@ class SimulatorOptionsDialog extends Dialog {
     this.simulatorOptions = options;
     this.currentMin = this.simulatorOptions.threshold_min;
     this.currentMax = this.simulatorOptions.threshold_max;
+    this.currentTwister = this.simulatorOptions.includeTwister;
+    this.currentSandstorm = this.simulatorOptions.includeSandstorm;
 
     this.#update(true);
   }


### PR DESCRIPTION
Added option to include sandstorm and twister for the "More" dungeon simulation (asked by Milado). I quess especially sandstorm might be quite handy for late game players. Twister is generally lacking the data so it's not optimal, do we have any data gathering in this department?

**Checklist:**
- [x] Have tested the modifications by running local server
