### PR TITLE
Fixed wrong bard notes color

### DIFF
--- a/js/pages/analyzer.js
+++ b/js/pages/analyzer.js
@@ -999,7 +999,7 @@ Site.ready({ name: 'analyzer', requires: ['translations_monsters'] }, function (
             if (state.type === 'druid_rage') {
                 return copyMode ? 'druid_rage' : `<i class="ui paw icon text-orangered" title="${intl('analyzer.special_state.druid_rage')}"></i>`;
             } else if (state.type === 'bard_song') {
-                return copyMode ? `bard_song_${state.level}` : `<span title="${intl('analyzer.special_state.bard_song')}" style="color: #${BARD_NOTE_COLORS[state.level]};">${state.notes} <i class="ui itunes note icon"></i></span>`;
+                return copyMode ? `bard_song_${state.level}` : `<span title="${intl('analyzer.special_state.bard_song')}" style="color: #${BARD_NOTE_COLORS[state.level - 1]};">${state.notes} <i class="ui itunes note icon"></i></span>`;
             } else if (state.type === 'berserker_rage') {
                 return copyMode ? 'berserker_rage' : `<i class="ui bolt icon text-orangered" title="${intl('analyzer.special_state.berserker_rage')}"></i>`;
             } else if (state.type === 'necromancer_minion') {


### PR DESCRIPTION
**Checklist:**
- [x] Have tested the modifications by running local server


Bard's notes colors in analyzer are wrong:
<img width="1175" height="432" alt="image" src="https://github.com/user-attachments/assets/54c98915-4ca0-41ce-b1e0-28f080294d16" />
